### PR TITLE
Adding Cu BLM and Unit Conversion function

### DIFF
--- a/R/CuBLM_Transform.R
+++ b/R/CuBLM_Transform.R
@@ -1,0 +1,43 @@
+#create a function that converts data from AWQMS long table format into the wide table format that
+#is used by the copper BLM model and the NPDES Copper BLM templates
+
+CuBLM<-function(x) {
+  #x is table output from AWQMS query
+
+  #Need to check units and make sure they are converted properly
+  x<-unit_conv(x,"Temperature, water","deg F","deg C")
+  x<-unit_conv(x,c("Calcium","Chloride","Magnesium","Potassium","Sodium","Sulfate","Organic carbon","Total Sulfate","Sulfide"),"ug/l","mg/l")
+  x<-unit_conv(x,"Copper","mg/l","ug/l")
+
+
+  # Analytes of interest for Copper BLM
+  char<-c("Alkalinity, total","Calcium","Chloride","Copper","Magnesium","pH","Potassium","Sodium","Sulfate","Organic carbon",
+          "Temperature, water","Total Sulfate","Sulfide","Salinity","Conductivity")
+
+  #Only want to keep analytes of interest, and remove any samples that are calculated from continuous data (eg. 7 day min)
+  y<-subset(x,x$Char_Name %in% char & is.na(x$Statistical_Base)) #&
+
+  #combine name and sample fraction, otherwise we get a bunch of rows we don't need
+  #mostly interested in whether an analyte is Total Recoverable or Dissolved, and only for metals
+  #can leave out the other Sample Fractions
+  y$Char_Name<-
+    case_when(y$Char_Name %in% c("Calcium","Copper","Magnesium","Potassium","Sodium","Organic carbon")
+              ~paste0(y$Char_Name,",",y$Sample_Fraction),
+              y$Char_Name %in% c("Alkalinity, total","Chloride","pH","Sulfate","Temperature, water","Total Sulfate","Sulfide","Salinity","Conductivity")
+              ~y$Char_Name)
+
+
+  #just want a subset of the columns, too many columns makes reshape very complicated
+  x<-subset(y,select=c("Char_Name","Result","SampleStartDate","SampleStartTime","OrganizationID","MLocID","Project1"))
+
+  res<-reshape(x, timevar="Char_Name",
+               idvar=c("MLocID","SampleStartDate","SampleStartTime","OrganizationID","Project1"),
+               direction="wide")
+
+  #note, if you get warnings with res saying that multiple rows match, look for duplicates in data
+
+  return(res)
+}
+
+
+

--- a/R/Unit_Convert.R
+++ b/R/Unit_Convert.R
@@ -1,0 +1,66 @@
+#unit transform function
+#originally designed for Copper BLM, so focuses on temperature, and ug-mg-ng conversions
+
+
+unit_conv<-function(x,char,unit,conv){
+  require(dplyr)
+  #x is dataset,char is characteristics,
+  #unit is what units the data is currently in,
+  #conv is what we want the units to be
+
+  #convert Result_Numeric
+  x$Result_Numeric<-case_when(x$Char_Name %in% char & x$Result_Unit==unit & unit=="deg F" & conv=="deg C"~((x$Result_Numeric-32)*0.5556),
+                              x$Char_Name %in% char & x$Result_Unit==unit & unit=="ug/l" & conv=="mg/l"~(x$Result_Numeric*0.001),
+                              x$Char_Name %in% char & x$Result_Unit==unit & unit=="mg/l" & conv=="ug/l"~(x$Result_Numeric*1000),
+                              x$Char_Name %in% char & x$Result_Unit==unit & unit=="ng/l" & conv=="ug/l"~(x$Result_Numeric/1000),
+                              !(x$Char_Name %in% char & x$Result_Unit==unit)~x$Result_Numeric)
+
+  #change unit to new unit
+  x$Result_Unit<-case_when(x$Char_Name %in% char & x$Result_Unit==unit & unit=="deg F" & conv=="deg C"~"deg C",
+                           x$Char_Name %in% char & x$Result_Unit==unit & unit=="ug/l" & conv=="mg/l"~"mg/l",
+                           x$Char_Name %in% char & x$Result_Unit==unit & unit=="mg/l" & conv=="ug/l"~"ug/l",
+                           x$Char_Name %in% char & x$Result_Unit==unit & unit=="ng/l" & conv=="ug/l"~"ug/l",
+                           !(x$Char_Name %in% char & x$Result_Unit==unit)~x$Result_Unit)
+
+   #change MDL and MRL values and units
+  x$MDLValue<-case_when(x$Char_Name %in% char & x$MDLUnit==unit & unit=="deg F" & conv=="deg C"~((x$MDLValue-32)*0.5556),
+                        x$Char_Name %in% char & x$MDLUnit==unit & unit=="ug/l" & conv=="mg/l"~(x$MDLValue*0.001),
+                        x$Char_Name %in% char & x$MDLUnit==unit & unit=="mg/l" & conv=="ug/l"~(x$MDLValue*1000),
+                        x$Char_Name %in% char & x$MDLUnit==unit & unit=="ng/l" & conv=="ug/l"~(x$MDLValue/1000),
+                        !(x$Char_Name %in% char & x$MDLUnit==unit)~x$MDLValue)
+
+  x$MDLUnit<-case_when(x$Char_Name %in% char& x$MDLUnit==unit & unit=="deg F"& conv=="deg C"~"deg C",
+                       x$Char_Name %in% char& x$MDLUnit==unit & unit=="ug/l"& conv=="mg/l"~"mg/l",
+                       x$Char_Name %in% char& x$MDLUnit==unit & unit=="mg/l"&conv=="ug/l"~"ug/l",
+                       x$Char_Name %in% char & x$MDLUnit==unit & unit=="ng/l" & conv=="ug/l"~"ug/l",
+                       !(x$Char_Name %in% char&x$MDLUnit==unit)~x$MDLUnit)
+
+  x$MRLValue<-case_when(x$Char_Name %in% char & x$MRLUnit==unit & unit=="deg F"& conv=="deg C"~((x$MRLValue-32)*0.5556),
+                        x$Char_Name %in% char & x$MRLUnit==unit & unit=="ug/l"& conv=="mg/l"~(x$MRLValue*0.001),
+                        x$Char_Name %in% char & x$MRLUnit==unit & unit=="mg/l"&conv=="ug/l"~(x$MRLValue*1000),
+                        x$Char_Name %in% char & x$MRLUnit==unit & unit=="ng/l" & conv=="ug/l"~(x$MRLValue/1000),
+                        !(x$Char_Name %in% char & x$MRLUnit==unit)~x$MRLValue)
+
+  x$MRLUnit<-case_when(x$Char_Name %in% char & x$MRLUnit==unit & unit=="deg F"& conv=="deg C"~"deg C",
+                       x$Char_Name %in% char & x$MRLUnit==unit & unit=="ug/l"& conv=="mg/l"~"mg/l",
+                       x$Char_Name %in% char & x$MRLUnit==unit & unit=="mg/l"& conv=="ug/l"~"ug/l",
+                       x$Char_Name %in% char & x$MRLUnit==unit & unit=="ng/l" & conv=="ug/l"~"ug/l",
+                       !(x$Char_Name %in% char & x$MRLUnit==unit)~x$MRLUnit)
+
+
+  #we changed Result_Numeric, now we want to make sure that Result shows the same value by replacing it
+  #with result numeric concatenated with < for NDs (or > when it exists)
+  x$Result<-paste0(ifelse(!(x$Result_Operator %in% "="),x$Result_Operator,""),x$Result_Numeric)
+
+  return(x)
+
+}
+
+#some test code
+#x<-AWQMS_Data(startdate = "2000-01-01", enddate = "2019-01-01", station = NULL, char = NULL, org = "GP-WM",
+#                  HUC8 = NULL, HUC8_Name = NULL)
+
+#test<-unit_conv(x,c("Calcium","Chloride","Magnesium","Potassium","Sodium","Sulfate","Organic carbon","Total Sulfate","Sulfide"),"ug/l","mg/l")
+
+#test2<-unit_conv(x,"Copper","mg/l","ug/l")
+


### PR DESCRIPTION
I added a copper BLM transformation function that puts the copper BLM parameters in wide table format (and does unit conversions). I also added a unit conversion function that does some simple conversions. If we want more unit conversions we'll have to add them as we go. 

I've used the tools on some of the permitting data I've dealt with, but I would strongly recommend trying them out on some of your data to make sure they're meeting your needs. 