### PR TITLE
Adding in HUC error checking

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: AWQMSdata
 Type: Package
 Title: Retrieves data from Oregon DEQ water quality database AWQMS
-Version: 1.6
+Version: 1.7
 Author: Travis Pritchard
 Maintainer: Travis Pritchard <pritchard.travis@deq.state.or.us>
 Description: Retrieves data from Oregon DEQ water quality database AWQMS. For internal DEQ use only. See documentation for setup and use. 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,5 @@
-# AWQMSdata 1.6
-
+# AWQMSdata 1.7 (2022-05-26)
+* Added error checks to AWQMSdata if numeric HUCs are not in character format. 
 
 # AWQMSdata 1.6 (2022-05-12)
 * Added return_query = FALSE as argument in AWQMS_Data. If true, will return actual query sent to AWQMS. Hopefully 

--- a/R/AWQMS_Data.R
+++ b/R/AWQMS_Data.R
@@ -68,6 +68,28 @@ AWQMS_Data <-
     # crit_codes = FALSE
     # filterQC = TRUE
 
+
+
+# Error checking -------------------------------------------------------------------------------------------------
+if(!(is.character(HUC8) | is.null(HUC8))){
+
+  stop('HUC8 value must be a character')
+}
+
+    if(!(is.character(HUC10) | is.null(HUC10))){
+
+      stop('HUC10 value must be a character')
+    }
+
+    if(!(is.character(HUC12) | is.null(HUC12))){
+
+      stop('HUC12 value must be a character')
+    }
+
+
+
+
+
   # Build base query language
 
   if(crit_codes == TRUE){


### PR DESCRIPTION
If numeric HUC designations are in numeric form, as opposed to character form, the query will cryptically fail. Adding in data type checks to catch this error earlier. 